### PR TITLE
fix: dispose fengmap when unmount FengmapBase

### DIFF
--- a/src/FengmapBase.js
+++ b/src/FengmapBase.js
@@ -76,7 +76,6 @@ class FengmapBase extends Component {
       this.mapContainer.current.innerHTML = ''
     }
     this.mapInstance = new fengmapSDK.FMMap(Object.assign({}, mapOptions, { container: this.mapContainer.current }))
-
     EVENTS.forEach(e => {
       this.mapInstance.on(e, event => {
         if (e === 'loadComplete') {
@@ -140,6 +139,10 @@ class FengmapBase extends Component {
     EVENTS.forEach(e => {
       this.mapInstance.off(e)
     })
+    if (typeof this.mapInstance.dispose === 'function') {
+      this.mapInstance.dispose()
+    }
+    this.mapInstance = null
   }
 
   render() {

--- a/src/FengmapBase.js
+++ b/src/FengmapBase.js
@@ -84,8 +84,12 @@ class FengmapBase extends Component {
           this._initAllChildren(this.mapInstance)
           initFloorsToMapInstance(this.mapInstance)
         }
+
         if (events && events[e]) {
           events[e](event, this.mapInstance)
+        }
+        if (!this.mapInstance) {
+          return
         }
         if (events && events.mapHoverNode) {
           this.mapInstance.gestureEnableController.enableMapHover = true
@@ -140,9 +144,12 @@ class FengmapBase extends Component {
       this.mapInstance.off(e)
     })
     if (typeof this.mapInstance.dispose === 'function') {
-      this.mapInstance.dispose()
+      try {
+        this.mapInstance.dispose()
+      } catch (err) {
+        console.log(err)
+      }
     }
-    this.mapInstance = null
   }
 
   render() {


### PR DESCRIPTION
1.在FengmapBase的componentWillUnmount方法中，销毁fengmap以释放内存
2.在销毁fengmap的方法中，增加对fengmap 2.2.0公开版sdk中销毁fengmap时的异常捕获
3.增加对fengmap事件处理时对于fengmap实例是否存在的判断